### PR TITLE
search: add braces around do_move

### DIFF
--- a/src/scout.cpp
+++ b/src/scout.cpp
@@ -299,9 +299,10 @@ SkipToNextGame:
 
           // Do the move after rule checking
           move = *data;
-          if (move)
+          if (move) {
               movedPiece = pos.moved_piece(move);
               pos.do_move(move, *st++, pos.gives_check(move));
+          }
 
       } while (*data++ != MOVE_NONE); // Exit the game loop pointing to next ofs
 


### PR DESCRIPTION
clang-10.0.0 warns about this misleading indentation as follows:

> scout.cpp: In function 'void Scout::search(Thread*)':
> scout.cpp:302:11: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
>   302 |           if (move)
>       |           ^~
> scout.cpp:304:15: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the '
> if'
>   304 |               pos.do_move(move, *st++, pos.gives_check(move));
>       |               ^~~

This looks like a bug to me as the condition `move==MOVE_NONE` will
cause a NULL pointer dereference in `do_move`.

Signed-off-by: Ali Polatel <alip@exherbo.org>